### PR TITLE
Add configure interval through env vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"io/ioutil"
 	"os"
+	"strconv"
 
 	"gopkg.in/yaml.v2"
 )
@@ -89,12 +90,24 @@ func loadFromEnv(config *Config) error {
 	config.Evaluate = getEnv(evaluateEnvName, config.Evaluate)
 	config.Metric = getEnv(metricEnvName, config.Metric)
 	config.Namespace = getEnv(namespaceEnvName, config.Namespace)
+	config.Interval = getEnvInt(intervalEnvName, config.Interval)
 	return nil
 }
 
 func getEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
+	}
+	return fallback
+}
+
+func getEnvInt(key string, fallback int) int {
+	if value, ok := os.LookupEnv(key); ok {
+		intVal, err := strconv.Atoi(value)
+		if err != nil {
+			return fallback
+		}
+		return intVal
 	}
 	return fallback
 }

--- a/example/python/cpa.yaml
+++ b/example/python/cpa.yaml
@@ -5,3 +5,6 @@ metadata:
 spec:
   image: example-python-custom-pod-autoscaler:latest
   selector: app=flask-metric
+  config: 
+    - name: INTERVAL
+      value: "5000"


### PR DESCRIPTION
Can now specify the interval in the Custom Pod Autoscaler
Custom Resource YAML.

Resolves #22.