### PR TITLE
Switch from updating to patching the target

### DIFF
--- a/internal/scaling/scaling_test.go
+++ b/internal/scaling/scaling_test.go
@@ -56,18 +56,18 @@ func TestScale_Scale(t *testing.T) {
 		scaleResource *autoscalingv1.Scale
 	}{
 		{
-			"Fail to update scale for resource",
+			"Fail to patch scale for resource",
 			nil,
-			errors.New("failed to apply scaling changes to resource: fail to update resource"),
+			errors.New("failed to apply scaling changes to resource: fail to patch resource"),
 			&scaling.Scale{
 				&scaleFake.FakeScaleClient{
 					Fake: k8stesting.Fake{
 						ReactionChain: []k8stesting.Reactor{
 							&k8stesting.SimpleReactor{
-								Resource: "deployment",
-								Verb:     "update",
+								Resource: "deployments",
+								Verb:     "patch",
 								Reaction: func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
-									return true, nil, errors.New("fail to update resource")
+									return true, nil, errors.New("fail to patch resource")
 								},
 							},
 						},


### PR DESCRIPTION
Fix the race condition for target resources that can be changed during CPA operations:
```
Error while autoscaling: failed to scale resource: failed to apply scaling changes to resource:

Operation cannot be fulfilled on deployments.apps:
the object has been modified; please apply your changes to the latest version and try again.
```

One of the common reasons for this issue is `status.availableReplicas` field being updated multiple times a second in large churning Deployments. Each time resource changes Kubernetes updates `metadata.resourceVersion` and rejects the update if resource versions do not match.

Switching to patching only the replica count helps to avoid the issue altogether. This patch should work for all supported target resource types.